### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/EmilySmith/1409774a-deba-4752-b406-1588816dcc0a/bdb85b6d-2723-4ed9-82ea-88ef58060ea6/_apis/work/boardbadge/a3f8d23b-ee2b-4ee4-b86d-3402707c6a92)](https://dev.azure.com/EmilySmith/1409774a-deba-4752-b406-1588816dcc0a/_boards/board/t/bdb85b6d-2723-4ed9-82ea-88ef58060ea6/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/EmilySmith/1409774a-deba-4752-b406-1588816dcc0a/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.